### PR TITLE
Twis 78/delete post comment

### DIFF
--- a/src/app/_components/DeletePostComment/DeletePostComment.stories.tsx
+++ b/src/app/_components/DeletePostComment/DeletePostComment.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import React from "react";
+import { Box } from "@mui/material";
+import { DeletePostComment } from "./DeletePostComment";
+
+const meta = {
+  title: "Authentication/DeletePostComment",
+  component: DeletePostComment,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {},
+  decorators: [
+    (Story) => (
+      <Box width={"350px"}>
+        <Story />
+      </Box>
+    ),
+  ],
+} satisfies Meta<typeof DeletePostComment>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { type: "Post" },
+};

--- a/src/app/_components/DeletePostComment/DeletePostComment.stories.tsx
+++ b/src/app/_components/DeletePostComment/DeletePostComment.stories.tsx
@@ -5,7 +5,7 @@ import { Box } from "@mui/material";
 import { DeletePostComment } from "./DeletePostComment";
 
 const meta = {
-  title: "Authentication/DeletePostComment",
+  title: "Components/DeletePostComment",
   component: DeletePostComment,
   parameters: {
     layout: "centered",

--- a/src/app/_components/DeletePostComment/DeletePostComment.tsx
+++ b/src/app/_components/DeletePostComment/DeletePostComment.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import * as React from "react";
+import Button from "@mui/material/Button";
+import { styled } from "@mui/material/styles";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import IconButton from "@mui/material/IconButton";
+import CloseIcon from "@mui/icons-material/Close";
+import Typography from "@mui/material/Typography";
+import { Box } from "@mui/material";
+
+interface Props {
+  type: "Post" | "Comment";
+  onDeleteClick?: () => void;
+}
+
+const BootstrapDialog = styled(Dialog)(({ theme }) => ({
+  "& .MuiDialogContent-root": {
+    padding: theme.spacing(2),
+  },
+  "& .MuiDialogActions-root": {
+    padding: theme.spacing(1),
+  },
+}));
+
+const DeletePostComment = ({ type, onDeleteClick }: Props) => {
+  const [open, setOpen] = React.useState(false);
+
+  const handleClickOpen = () => {
+    setOpen(true);
+  };
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <React.Fragment>
+      <Button variant="text" onClick={handleClickOpen}>
+        Delete
+      </Button>
+      <BootstrapDialog
+        onClose={handleClose}
+        aria-labelledby="customized-dialog-title"
+        open={open}
+      >
+        <DialogTitle
+          sx={{ m: 0, p: 2, fontSize: "25px", fontWeight: "bold" }}
+          id="customized-dialog-title"
+          //   color={"white"}
+        >
+          Delete post?
+        </DialogTitle>
+        <IconButton
+          aria-label="close"
+          onClick={handleClose}
+          sx={{
+            position: "absolute",
+            right: 8,
+            top: 8,
+            color: (theme) => theme.palette.grey[500],
+          }}
+        >
+          <CloseIcon />
+        </IconButton>
+        <DialogContent dividers>
+          <Typography sx={{ color: "text.secondary" }}>
+            Are you sure you want to delete this {type}?
+          </Typography>
+        </DialogContent>
+        <DialogActions sx={{ justifyContent: "center" }}>
+          <Box>
+            <Button
+              sx={{
+                background: "red",
+                borderRadius: "33px",
+              }}
+              variant="contained"
+              onClick={onDeleteClick}
+            >
+              Delete
+            </Button>
+            <Button sx={{ borderRadius: "33px" }} variant="contained">
+              Cancel
+            </Button>
+          </Box>
+        </DialogActions>
+      </BootstrapDialog>
+    </React.Fragment>
+  );
+};
+
+export { DeletePostComment };

--- a/src/app/_components/DeletePostComment/DeletePostComment.tsx
+++ b/src/app/_components/DeletePostComment/DeletePostComment.tsx
@@ -10,7 +10,6 @@ import DialogActions from "@mui/material/DialogActions";
 import IconButton from "@mui/material/IconButton";
 import CloseIcon from "@mui/icons-material/Close";
 import Typography from "@mui/material/Typography";
-import { Box } from "@mui/material";
 
 interface Props {
   type: "Post" | "Comment";
@@ -22,23 +21,29 @@ const BootstrapDialog = styled(Dialog)(({ theme }) => ({
     padding: theme.spacing(2),
   },
   "& .MuiDialogActions-root": {
-    padding: theme.spacing(1),
+    padding: theme.spacing(2),
   },
 }));
 
 const DeletePostComment = ({ type, onDeleteClick }: Props) => {
   const [open, setOpen] = React.useState(false);
 
-  const handleClickOpen = () => {
+  const handleOpen = () => {
     setOpen(true);
   };
+
   const handleClose = () => {
     setOpen(false);
   };
 
+  const handleDeleteClick = () => {
+    onDeleteClick?.();
+    handleClose();
+  };
+
   return (
     <React.Fragment>
-      <Button variant="text" onClick={handleClickOpen}>
+      <Button variant="text" onClick={handleOpen}>
         Delete
       </Button>
       <BootstrapDialog
@@ -47,11 +52,10 @@ const DeletePostComment = ({ type, onDeleteClick }: Props) => {
         open={open}
       >
         <DialogTitle
-          sx={{ m: 0, p: 2, fontSize: "25px", fontWeight: "bold" }}
+          sx={{ m: 0, p: 2, fontSize: "25px" }}
           id="customized-dialog-title"
-          //   color={"white"}
         >
-          Delete post?
+          Delete {type}?
         </DialogTitle>
         <IconButton
           aria-label="close"
@@ -70,22 +74,13 @@ const DeletePostComment = ({ type, onDeleteClick }: Props) => {
             Are you sure you want to delete this {type}?
           </Typography>
         </DialogContent>
-        <DialogActions sx={{ justifyContent: "center" }}>
-          <Box>
-            <Button
-              sx={{
-                background: "red",
-                borderRadius: "33px",
-              }}
-              variant="contained"
-              onClick={onDeleteClick}
-            >
-              Delete
-            </Button>
-            <Button sx={{ borderRadius: "33px" }} variant="contained">
-              Cancel
-            </Button>
-          </Box>
+        <DialogActions>
+          <Button variant="outlined" color="inherit" onClick={handleClose}>
+            Cancel
+          </Button>
+          <Button variant="contained" color="error" onClick={handleDeleteClick}>
+            Delete
+          </Button>
         </DialogActions>
       </BootstrapDialog>
     </React.Fragment>

--- a/src/app/_components/DeletePostComment/index.ts
+++ b/src/app/_components/DeletePostComment/index.ts
@@ -1,0 +1,1 @@
+export { DeletePostComment } from "./DeletePostComment";

--- a/src/app/_components/index.ts
+++ b/src/app/_components/index.ts
@@ -16,3 +16,4 @@ export { CreatePost } from "./CreatePost";
 export { VisuallyHiddenInput } from "./VisuallyHiddenInput";
 export { EmojiPicker } from "./EmojiPicker";
 export { ImageContainer } from "./ImageContainer";
+export { DeletePostComment } from "./DeletePostComment";


### PR DESCRIPTION
# Twis 78/delete post comment

## Link to Story

https://re-boot.atlassian.net/browse/TWIS-78

## Description

The modal should say “Delete post” or “Delete comment” based on the prop that’s passed in to the component

Delete should have a onClick that will get its callback function as a prop to the component


## Screenshot(s) / GIF(s):
<img width="598" alt="image" src="https://github.com/Re-boot-Coding-Bootcamp/TwistaGram/assets/158536270/23c464f5-c8e0-4f4b-8ee0-378dad569275">



## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Dependency / Configuration update
- [ ] Documentation update

## Checklist:

- [x] My code follows the project's style guidelines
- [x] I have created a Storybook story for my component(s)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
