### PR TITLE
TWIS-100/cancel-button-on-edit-profile

### DIFF
--- a/src/app/_components/CreateUpdateProfileForm/CreateUpdateProfileForm.tsx
+++ b/src/app/_components/CreateUpdateProfileForm/CreateUpdateProfileForm.tsx
@@ -22,7 +22,6 @@ const CreateUpdateProfileForm = ({
 
   const handleCancel = () => {
     if (!username || !name) {
-      alert("please fill out both USERNAME and NAME");
       return;
     }
     onCancel;

--- a/src/app/_components/CreateUpdateProfileForm/CreateUpdateProfileForm.tsx
+++ b/src/app/_components/CreateUpdateProfileForm/CreateUpdateProfileForm.tsx
@@ -20,6 +20,14 @@ const CreateUpdateProfileForm = ({
   const [username, setUsername] = useState(user.username ?? "");
   const [bio, setBio] = useState(user.bio ?? "");
 
+  const handleCancel = () => {
+    if (!username || !name) {
+      alert("please fill out both USERNAME and NAME");
+      return;
+    }
+    onCancel;
+  };
+
   const handleSave = () => {
     const updatedUser: UpdateUserInput = {
       name: name,
@@ -81,7 +89,7 @@ const CreateUpdateProfileForm = ({
         <Button
           variant="outlined"
           color="primary"
-          onClick={onCancel}
+          onClick={handleCancel}
           text="Cancel"
           style={{ backgroundColor: "white" }}
         />


### PR DESCRIPTION
# TWIS-100/cancel-button-on-edit-profile

## Link to Story

https://re-boot.atlassian.net/browse/TWIS-100

## Description

cancel button on the edit profile page to "not allow" user to cancel if the required fields are not filled out 

## Screenshot(s) / GIF(s):

<img width="587" alt="image" src="https://github.com/Re-boot-Coding-Bootcamp/TwistaGram/assets/158536270/f1d17f60-e196-4d3b-9beb-9265db7f29bd">


## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Dependency / Configuration update
- [ ] Documentation update

## Checklist:

- [x] My code follows the project's style guidelines
- [ ] I have created a Storybook story for my component(s)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
