### PR TITLE
TWIS-79/inline-reply

### DIFF
--- a/src/app/_components/InlineReply/InlineReply.stories.tsx
+++ b/src/app/_components/InlineReply/InlineReply.stories.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { Box } from "@mui/material";
+import type { Meta, StoryObj } from "@storybook/react";
+import { InlineReply } from "./InlineReply";
+
+const meta: Meta<typeof InlineReply> = {
+  title: "Components/InlineReply",
+  component: InlineReply,
+  decorators: [
+    (Story) => (
+      <Box width={"500px"}>
+        <Story />
+      </Box>
+    ),
+  ],
+};
+
+export default meta;
+
+type InlineReplyStory = StoryObj<typeof InlineReply>;
+
+export const Default: InlineReplyStory = {
+  args: {},
+};

--- a/src/app/_components/InlineReply/InlineReply.tsx
+++ b/src/app/_components/InlineReply/InlineReply.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import React, { useState } from "react";
+import { Box, Input, Button, useTheme } from "@mui/material";
+import { Avatar } from "../Avatar";
+
+interface InlineReplyProps {
+  onReplySubmit: (content: string) => void;
+}
+
+const InlineReply: React.FC<InlineReplyProps> = ({ onReplySubmit }) => {
+  const theme = useTheme();
+  const [replyText, setReplyText] = useState<string>("");
+  const [isActive, setIsActive] = useState<boolean>(false);
+
+  const handleReplySubmit = () => {
+    if (replyText.trim()) {
+      onReplySubmit(replyText.trim());
+      setReplyText("");
+      setIsActive(false);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleReplySubmit();
+    }
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setReplyText(e.target.value);
+    setIsActive(e.target.value.trim() !== "");
+  };
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        height: "100vh",
+        width: "100vw",
+        position: "fixed",
+        top: 0,
+        left: 0,
+        flexDirection: "column",
+        [theme.breakpoints.up("sm")]: {
+          marginTop: 10,
+          height: "auto",
+          alignItems: "center",
+        },
+        [theme.breakpoints.down("sm")]: {
+          alignItems: "center",
+          justifyContent: "flex-start",
+        },
+      }}
+    >
+      <Box
+        sx={{
+          width: "100%",
+          maxWidth: "500px",
+          p: 3,
+          [theme.breakpoints.down("sm")]: {
+            maxWidth: "100vw",
+          },
+        }}
+      >
+        <Box display="flex" gap={2}>
+          <Avatar size="medium" />
+          <Input
+            type="text"
+            placeholder="Post your reply"
+            value={replyText}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+            style={{ width: "100%", paddingBottom: 10 }}
+          />
+          <Button
+            variant="contained"
+            onClick={handleReplySubmit}
+            disabled={!isActive}
+            sx={{
+              borderRadius: 30,
+              width: 100,
+              height: 40,
+              fontSize: 15,
+              bgcolor: theme.palette.primary.main,
+            }}
+          >
+            Reply
+          </Button>
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export { InlineReply };

--- a/src/app/_components/InlineReply/index.ts
+++ b/src/app/_components/InlineReply/index.ts
@@ -1,0 +1,1 @@
+export { InlineReply } from "./InlineReply";

--- a/src/app/_components/index.ts
+++ b/src/app/_components/index.ts
@@ -23,3 +23,5 @@ export { CommentIcon } from "./CommentIcon";
 export { ChangeProfilePhoto } from "./ChangeProfilePhoto";
 export { LoadingScreen } from "./LoadingScreen";
 export { ErrorScreen } from "./ErrorScreen";
+export { InlineReply } from "./InlineReply";
+


### PR DESCRIPTION
# TWIS-79/inline-reply

## Link to Story

https://re-boot.atlassian.net/browse/TWIS-79

## Description

The reply button expect a call back function from prop to be called onClick

The component have “Active” and “Inactive” states

When a reply is submitted, the component state should be reset, including clearing out content and setting it back to “Inactive” state

Keyboard “Enter” submit the reply if it’s ready to be submitted

## Screenshot(s) / GIF(s):

![Mar-27-2024 22-26-30](https://github.com/Re-boot-Coding-Bootcamp/TwistaGram/assets/158520785/0c1e6c63-4235-4245-bf3f-def197d35123)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Dependency / Configuration update
- [ ] Documentation update

## Checklist:

- [x] My code follows the project's style guidelines
- [x] I have created a Storybook story for my component(s)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
